### PR TITLE
Remove OC link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-open_collective: nerves-project


### PR DESCRIPTION
This project isn't supported by the Nerves core team any more, so the
current funding link would be sending money to the wrong place.
