### PR TITLE
Fix `deploy-system` action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,12 @@ jobs:
     needs: [build-system]
     if: github.ref_type == 'tag'
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: gridpoint-com/actions-nerves-system@v1
       - name: Deploy nerves_system
         uses: ./.actions/deploy-system
         with:
-          github-token: ${{ secrets.ARTIFACT_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
A new version of `actions-nerves-system` was created which switched to using `gh` CLI instead of the old external `ghr`.

This adjusts the `deploy-system` action setup to support that and have the right permissions to post the release